### PR TITLE
Add first login page with platform auth buttons

### DIFF
--- a/static/firstLogin.css
+++ b/static/firstLogin.css
@@ -1,0 +1,38 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f4f4f4;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.auth-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.auth-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 15px;
+    width: 300px;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 16px;
+}
+
+.auth-button i {
+    font-size: 20px;
+}
+
+.auth-button.youtube { background: #FF0000; }
+.auth-button.twitch { background: #9146FF; }
+.auth-button.threads { background: #000000; }
+
+.auth-button:hover { opacity: 0.9; }

--- a/templates/firstLogin.html
+++ b/templates/firstLogin.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Connect Accounts</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='firstLogin.css') }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-+0s0JgtE1UnIFmLKaRGjn3hw5sxI7O4rdvXXDuMLGkjStHeI5GdYecsBC4VYmgJ2OU5GQvPp1Oph+cJn51p9eg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <div class="auth-container">
+        <a class="auth-button youtube" href="{{ url_for('connectYoutube') }}">
+            <i class="fa-brands fa-youtube"></i>
+            Continue with YouTube
+        </a>
+        <a class="auth-button twitch" href="{{ url_for('connect_twitch') }}">
+            <i class="fa-brands fa-twitch"></i>
+            Continue with Twitch
+        </a>
+        <a class="auth-button threads" href="{{ url_for('connectThreads') }}">
+            <i class="fa-brands fa-threads"></i>
+            Continue with Threads
+        </a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add first login page with buttons to connect YouTube, Twitch, and Threads accounts
- Style first login buttons with brand colors and icons

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: user.py expected ':' at line 4)*

------
https://chatgpt.com/codex/tasks/task_e_688c6bfe82208333bfcd26d5e11bebe7