### PR TITLE
Revamp auth pages layout and styling

### DIFF
--- a/static/login.css
+++ b/static/login.css
@@ -1,36 +1,89 @@
 body {
-    font-family: Arial, sans-serif;
-    background: #f4f4f4;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     margin: 0;
+    font-family: Arial, sans-serif;
+    height: 100vh;
 }
 
-form {
+.login-container {
+    display: flex;
+    height: 100%;
+}
+
+.left-panel {
+    flex: 1;
+    max-width: 20%;
     background: #fff;
-    padding: 20px;
-    border-radius: 4px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    width: 300px;
+    padding: 40px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 }
 
-input {
-    display: block;
-    width: 100%;
-    margin: 10px 0;
-    padding: 8px;
+.left-panel .logo {
+    max-width: 100px;
+    margin-bottom: 10px;
 }
 
-button {
+.left-panel .title {
+    margin: 0 0 20px 0;
+}
+
+.left-panel form {
     width: 100%;
-    padding: 8px;
+    display: flex;
+    flex-direction: column;
+}
+
+.left-panel label {
+    margin-top: 10px;
+}
+
+.left-panel input {
+    padding: 10px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    box-sizing: border-box;
+    transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.left-panel input:focus {
+    outline: none;
+    border-color: #ff69b4;
+    box-shadow: 0 0 4px #ff69b4;
+}
+
+.left-panel button {
+    margin-top: 20px;
+    padding: 10px;
+    border: none;
+    border-radius: 10px;
+    background-color: #452567;
+    color: #fff;
+    cursor: pointer;
+}
+
+.signup-text {
+    margin: 10px 0 20px 0;
+}
+
+.signup-text a {
+    color: blue;
 }
 
 .flash-messages {
     color: red;
     list-style: none;
     padding: 0;
-    margin-bottom: 10px;
+    margin: 0 0 10px 0;
+}
+
+.right-panel {
+    flex: 4;
+    background-color: #452567;
+    background-image: url('images/BackgroundLoginPage.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
 }

--- a/static/signup.css
+++ b/static/signup.css
@@ -1,36 +1,89 @@
 body {
-    font-family: Arial, sans-serif;
-    background: #f4f4f4;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     margin: 0;
+    font-family: Arial, sans-serif;
+    height: 100vh;
 }
 
-form {
+.signup-container {
+    display: flex;
+    height: 100%;
+}
+
+.left-panel {
+    flex: 1;
+    max-width: 20%;
     background: #fff;
-    padding: 20px;
-    border-radius: 4px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    width: 300px;
+    padding: 40px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 }
 
-input {
-    display: block;
-    width: 100%;
-    margin: 10px 0;
-    padding: 8px;
+.left-panel .logo {
+    max-width: 100px;
+    margin-bottom: 10px;
 }
 
-button {
+.left-panel .title {
+    margin: 0 0 20px 0;
+}
+
+.left-panel form {
     width: 100%;
-    padding: 8px;
+    display: flex;
+    flex-direction: column;
+}
+
+.left-panel label {
+    margin-top: 10px;
+}
+
+.left-panel input {
+    padding: 10px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    box-sizing: border-box;
+    transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.left-panel input:focus {
+    outline: none;
+    border-color: #ff69b4;
+    box-shadow: 0 0 4px #ff69b4;
+}
+
+.left-panel button {
+    margin-top: 20px;
+    padding: 10px;
+    border: none;
+    border-radius: 10px;
+    background-color: #452567;
+    color: #fff;
+    cursor: pointer;
+}
+
+.login-text {
+    margin: 10px 0 20px 0;
+}
+
+.login-text a {
+    color: blue;
 }
 
 .flash-messages {
     color: red;
     list-style: none;
     padding: 0;
-    margin-bottom: 10px;
+    margin: 0 0 10px 0;
+}
+
+.right-panel {
+    flex: 4;
+    background-color: #452567;
+    background-image: url('images/BackgroundLoginPage.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,26 +6,34 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='login.css') }}">
 </head>
 <body>
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <ul class="flash-messages">
-          {% for message in messages %}
-            <li>{{ message }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    {% endwith %}
+    <div class="login-container">
+        <div class="left-panel">
+            <img src="{{ url_for('static', filename='images/Logo.png') }}" alt="Scepter logo" class="logo">
+            <h1 class="title">Scepter</h1>
+            <h2>Log into your account</h2>
+            <p class="signup-text">Don't have an account? <a href="{{ url_for('signup') }}">Sign up</a></p>
 
-    <form action="{{ url_for('login') }}" method="post">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" required>
+            {% with messages = get_flashed_messages() %}
+              {% if messages %}
+                <ul class="flash-messages">
+                  {% for message in messages %}
+                    <li>{{ message }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            {% endwith %}
 
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" required>
+            <form action="{{ url_for('login') }}" method="post">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required>
 
-        <button type="submit">Login</button>
-    </form>
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
 
-    <p>Don't have an account? <a href="{{ url_for('signup') }}">Sign Up</a></p>
+                <button type="submit">Login</button>
+            </form>
+        </div>
+        <div class="right-panel"></div>
+    </div>
 </body>
 </html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -6,32 +6,40 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='signup.css') }}">
 </head>
 <body>
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <ul class="flash-messages">
-          {% for message in messages %}
-            <li>{{ message }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    {% endwith %}
+    <div class="signup-container">
+        <div class="left-panel">
+            <img src="{{ url_for('static', filename='images/Logo.png') }}" alt="Scepter logo" class="logo">
+            <h1 class="title">Scepter</h1>
+            <h2>Create your account</h2>
+            <p class="login-text">Already have an account? <a href="{{ url_for('login') }}">Log in</a></p>
 
-    <form action="{{ url_for('signup') }}" method="post">
-        <label for="name">Name</label>
-        <input type="text" id="name" name="name" required>
-        
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" required>
+            {% with messages = get_flashed_messages() %}
+              {% if messages %}
+                <ul class="flash-messages">
+                  {% for message in messages %}
+                    <li>{{ message }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            {% endwith %}
 
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" required>
+            <form action="{{ url_for('signup') }}" method="post">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" required>
 
-        <label for="confirm_password">Confirm Password</label>
-        <input type="password" id="confirm_password" name="confirm_password" required>
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required>
 
-        <button type="submit">Sign Up</button>
-    </form>
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
 
-    <p>Already have an account? <a href="{{ url_for('login') }}">Log in</a></p>
+                <label for="confirm_password">Confirm Password</label>
+                <input type="password" id="confirm_password" name="confirm_password" required>
+
+                <button type="submit">Sign Up</button>
+            </form>
+        </div>
+        <div class="right-panel"></div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Match signup page to new login layout with left/right panels, logo, and interactive form
- Ensure background image only contains within the panel for both login and signup pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c89b94c34833382440cd03b8abaa1