### PR TITLE
Improve first login page UI and navigation

### DIFF
--- a/static/firstLogin.css
+++ b/static/firstLogin.css
@@ -8,10 +8,16 @@ body {
     margin: 0;
 }
 
+.auth-wrapper {
+    text-align: center;
+}
+
 .auth-container {
     display: flex;
     flex-direction: column;
     gap: 20px;
+    margin-top: 30px;
+    margin-bottom: 20px;
 }
 
 .auth-button {
@@ -25,6 +31,7 @@ body {
     text-decoration: none;
     border-radius: 4px;
     font-size: 16px;
+    transition: background 0.3s ease;
 }
 
 .auth-button i {
@@ -35,4 +42,37 @@ body {
 .auth-button.twitch { background: #9146FF; }
 .auth-button.threads { background: #000000; }
 
+.auth-button.connected { background: #28a745; }
+.auth-button .check {
+    margin-left: 8px;
+}
+
 .auth-button:hover { opacity: 0.9; }
+
+.next-button {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 12px 40px;
+    background: #007BFF;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+.next-button:hover {
+    opacity: 0.9;
+}
+
+.skip-link {
+    margin-top: 15px;
+    font-size: 14px;
+}
+
+.skip-link a {
+    color: #007BFF;
+    text-decoration: none;
+}
+
+.skip-link a:hover {
+    text-decoration: underline;
+}

--- a/static/secondlogin.html
+++ b/static/secondlogin.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Second Login</title>
+</head>
+<body>
+    <h1>Second Login Page</h1>
+    <p>This is a placeholder for the next step of the login process.</p>
+</body>
+</html>

--- a/templates/firstLogin.html
+++ b/templates/firstLogin.html
@@ -7,19 +7,39 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-+0s0JgtE1UnIFmLKaRGjn3hw5sxI7O4rdvXXDuMLGkjStHeI5GdYecsBC4VYmgJ2OU5GQvPp1Oph+cJn51p9eg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
-    <div class="auth-container">
-        <a class="auth-button youtube" href="{{ url_for('connectYoutube') }}">
-            <i class="fa-brands fa-youtube"></i>
-            Continue with YouTube
-        </a>
-        <a class="auth-button twitch" href="{{ url_for('connect_twitch') }}">
-            <i class="fa-brands fa-twitch"></i>
-            Continue with Twitch
-        </a>
-        <a class="auth-button threads" href="{{ url_for('connectThreads') }}">
-            <i class="fa-brands fa-threads"></i>
-            Continue with Threads
-        </a>
+    <div class="auth-wrapper">
+        <h1>Connect Your Social Media Accounts</h1>
+        <p class="description">Log in with your preferred social media accounts to get started.</p>
+
+        <div class="auth-container">
+            <a class="auth-button youtube{% if session.get('youtube_token') %} connected{% endif %}" href="{{ url_for('connectYoutube') }}">
+                <i class="fa-brands fa-youtube"></i>
+                {% if session.get('youtube_token') %}
+                    YouTube Connected <i class="fa-solid fa-check check"></i>
+                {% else %}
+                    Continue with YouTube
+                {% endif %}
+            </a>
+            <a class="auth-button twitch{% if session.get('twitch_token') %} connected{% endif %}" href="{{ url_for('connect_twitch') }}">
+                <i class="fa-brands fa-twitch"></i>
+                {% if session.get('twitch_token') %}
+                    Twitch Connected <i class="fa-solid fa-check check"></i>
+                {% else %}
+                    Continue with Twitch
+                {% endif %}
+            </a>
+            <a class="auth-button threads{% if session.get('threads_token') %} connected{% endif %}" href="{{ url_for('connectThreads') }}">
+                <i class="fa-brands fa-threads"></i>
+                {% if session.get('threads_token') %}
+                    Threads Connected <i class="fa-solid fa-check check"></i>
+                {% else %}
+                    Continue with Threads
+                {% endif %}
+            </a>
+        </div>
+
+        <a class="next-button" href="{{ url_for('static', filename='secondlogin.html') }}">Next</a>
+        <p class="skip-link"><a href="{{ url_for('static', filename='secondlogin.html') }}">Continue without social media account</a></p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add descriptive header and social account buttons with icons and connection indicators
- Include next/skip links and placeholder second login page
- Style first login page with new layout and connected state visuals

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: user.py expected ':' at line 4)*
- `python -m py_compile server.py auth/*.py creator.py prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_688da2d7836483338ad6e03b934d65bd